### PR TITLE
Update to latest capnp-rpc and ocurrent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam2:debian-10-ocaml-4.08 AS build
 RUN sudo apt-get update && sudo apt-get install capnproto graphviz m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin master && git reset --hard 8bc187ff7168b47537d5bbd9b330a90ed90830ad && opam update
+RUN cd ~/opam-repository && git pull origin master && git reset --hard ca18b54339548dc814304558e87517e776016293 && opam update
 COPY --chown=opam \
 	ocurrent/current.opam \
 	ocurrent/current_web.opam \

--- a/base-images.opam
+++ b/base-images.opam
@@ -19,6 +19,6 @@ depends: [
   "current_slack"
   "current_web"
   "current_rpc"
-  "capnp-rpc-unix"
+  "capnp-rpc-unix" {>= "0.4.0"}
   "dockerfile-opam" {>= "6.2.0"}
 ]


### PR DESCRIPTION
This also fixes a build problem with the new x509 release.