### PR TITLE
Disable installing bytecode tools on OCaml >= 4.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam2:debian-10-ocaml-4.08 AS build
 RUN sudo apt-get update && sudo apt-get install capnproto graphviz m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin master && git reset --hard ca18b54339548dc814304558e87517e776016293 && opam update
+RUN cd ~/opam-repository && git pull origin master && git reset --hard c20fd2e06a93a123d4fe407a611c35a05670af83 && opam update
 COPY --chown=opam \
 	ocurrent/current.opam \
 	ocurrent/current_web.opam \

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -8,16 +8,13 @@ let opam_repository () =
   Current_git.clone ~schedule:weekly "git://github.com/ocaml/opam-repository"
 
 (* Prevent `.byte` executables from being installed, if possible. *)
-let try_disable_bytes _switch =
+let try_disable_bytes switch =
   let open Dockerfile in
-  (* Doesn't work, due to https://github.com/ocaml/ocaml/issues/8855 *)
-  (*
-  if Ocaml_version.compare switch Ocaml_version.Releases.v4_08_0 >= 0 then (
+  if Ocaml_version.compare switch Ocaml_version.Releases.v4_10_0 >= 0 then (
     run "sed -i 's!\"./configure\"!\"./configure\" \"--disable-installing-bytecode-programs\"!' \
-         /home/opam/opam-repository/packages/ocaml-base-compiler/%s/opam" (Ocaml_version.Opam.V2.name switch) @@
+         /home/opam/opam-repository/packages/ocaml-variants/%s/opam" (Ocaml_version.Opam.V2.name switch) @@
     run "cd opam-repository && git commit -a -m 'Disable bytecode binaries to save space'"
   ) else
-  *)
   empty
 
 let maybe_add_beta switch =


### PR DESCRIPTION
We can't do this on earlier versions due to a bug.