### PR TITLE
Create some aliases

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -158,7 +158,7 @@ let v ?channel () =
             (* For every distro, also create a link to the latest OCaml compiler.
                e.g. debian-9 -> debian-9-ocaml-4.09 *)
             let tags = Tag.v_alias distro :: tags in
-            (* If [distro] is the latest version of that distribuion, make an alias like
+            (* If [distro] is the latest version of that distribution, make an alias like
                debian -> debian-10-ocaml-4.09 *)
             match distro_latest_alias with
             | None -> tags

--- a/src/tag.ml
+++ b/src/tag.ml
@@ -18,3 +18,13 @@ let v ?arch ?switch distro =
     | None -> "opam"
   in
   Fmt.strf "%s:%s-%s%a" repo distro switch pp_arch arch
+
+let v_alias alias =
+  let alias =
+    if alias = `Debian `Stable then "debian"
+    else Dockerfile_distro.tag_of_distro alias
+  in
+  Fmt.strf "%s:%s" Conf.public_repo alias
+
+let latest =
+  Fmt.strf "%s:latest" Conf.public_repo

--- a/src/tag.mli
+++ b/src/tag.mli
@@ -3,3 +3,9 @@ val v : ?arch:Ocaml_version.arch -> ?switch:Ocaml_version.t -> Dockerfile_distro
     with OCaml compiler [switch] installed. If [switch] is [None] then this is a base image
     with no switches. If [arch] is set then this is a staging image, which will later be combined
     into a cross-platform image. *)
+
+val v_alias : Dockerfile_distro.t -> string
+(** [v_alias distro] is a short tag for [distro], without the OCaml version. *)
+
+val latest : string
+(** [latest] is the single ":latest" tag. *)


### PR DESCRIPTION
e.g. these tags now all point to the same image:

- ocurrent/opam:debian-10-ocaml-4.09
- ocurrent/opam:debian-10
- ocurrent/opam:debian
- ocurrent/opam:latest

(or will do in a few hours; it's rebuild day today)

/cc @avsm